### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ has something to build. Do not treat `src/Dummy.java` as real product code.
 
 ## Build & Test Commands
 
-There is no root build. Each module is built and run independently.
+There is no shared product build. Each module is built and run independently.
+The root Maven project exists only for the Sonar workflow.
 
 Run a module directly with Python (from inside the module directory, after
 installing its dependencies):
@@ -81,17 +82,16 @@ cd auditsweeper
 docker build -t auditsweeper:local .
 ```
 
-There are no unit or integration tests to run in this repo. The only CI
-quality gate is `sonar-check.yml`, which runs against the placeholder
-`pom.xml` at the repo root:
+There are no unit or integration tests to run in this repo. CI also runs
+Helm chart linting for changes under `helm/**`. `sonar-check.yml` runs against
+the placeholder `pom.xml` at the repo root:
 
 ```bash
 mvn -B verify sonar:sonar -Dsonar.projectKey=mosip_security-tools -Dsonar.organization=mosip -Dsonar.host.url=https://sonarcloud.io -DskipSigning=true
 ```
 
-Helm chart linting happens in CI only (`chart-lint-publish.yml`, triggered on
-changes under `helm/**`) — there is no documented local lint command in this
-repo; use `helm lint helm/<module>` if you need to check a chart locally.
+Helm chart linting runs in CI (`chart-lint-publish.yml`, triggered on changes
+under `helm/**`). Run `helm lint helm/<module>` locally when needed.
 
 ## Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,225 @@
+# AGENTS.md
+
+## Repository Overview
+
+`security-tools` is a collection of small, **independent** operational/security
+utility scripts used to run and maintain a MOSIP deployment. There is no shared
+application, shared library, or shared build — each module is its own
+standalone Python script with its own Dockerfile, its own Helm chart, and its
+own deploy scripts. Treat this repo as a toolbox, not a single service.
+
+Modules (each is independently deployable as a Kubernetes CronJob):
+
+| Module | Purpose | Guide |
+| --- | --- | --- |
+| `auditsweeper/` | Deletes old rows from the `audit.app_audit_log` table in the `mosip_audit` Postgres database, older than a configurable number of days. | [auditsweeper/AGENTS.md](auditsweeper/AGENTS.md) |
+| `certmanager/` | Checks MOSIP partner certificate expiry (via PMS) and renews/re-uploads certificates to eSignet, IDA, KeyManager, or PMS as needed. | [certmanager/AGENTS.md](certmanager/AGENTS.md) |
+| `databreachdetector/` | Scans Postgres tables for PII-shaped data (using the `deduce` library) and uploads findings reports to MinIO/S3. Marked **WIP** by its own README. | [databreachdetector/AGENTS.md](databreachdetector/AGENTS.md) |
+
+Two more top-level directories support all three modules but are not modules
+themselves:
+
+- `deploy/` — per-module shell scripts (`install.sh`, `delete.sh`,
+  `copy_cm.sh`, `copy_secrets.sh`) and `values.yaml` overrides used to install
+  each Helm chart onto a cluster. Subfolders are `deploy/auditsweeper/`,
+  `deploy/mosipcertmanager/`, `deploy/databreachdetector/` — note
+  `mosipcertmanager` here corresponds to the `certmanager/` module (see
+  Repository-Specific Considerations).
+- `helm/` — the three Helm charts (`helm/auditsweeper/`,
+  `helm/mosipcertmanager/`, `helm/databreachdetector/`), each deployed as a
+  Kubernetes `CronJob`.
+
+There is also a `pom.xml` and `src/Dummy.java` at the repo root. These are
+**not** a real application — they are a placeholder Maven project that exists
+only so the `sonar-check.yml` workflow (which runs `mvn verify sonar:sonar`)
+has something to build. Do not treat `src/Dummy.java` as real product code.
+
+## Technology Stack
+
+- **Language**: Python 3.9 (all three modules; see each module's Dockerfile
+  `FROM python:3.9`)
+- **Key Python libraries** (per module, see each `requirements.txt`):
+  `psycopg2-binary` (Postgres) everywhere; `requests` in `certmanager`;
+  `python-stdnum`, `deduce`, `minio` in `databreachdetector`
+- **Containers**: each module ships its own `Dockerfile`, built by CI
+- **Orchestration**: Kubernetes `CronJob` via Helm charts under `helm/`
+- **CI**: GitHub Actions (`.github/workflows/`) — Docker image builds, Helm
+  chart lint/publish, and a SonarCloud scan of the placeholder Maven project
+- **No test framework** is present anywhere in this repo (no `test_*.py`,
+  `pytest`, or similar files exist as of this writing)
+
+## Build & Test Commands
+
+There is no root build. Each module is built and run independently.
+
+Run a module directly with Python (from inside the module directory, after
+installing its dependencies):
+
+```bash
+cd auditsweeper
+pip install -r requirements.txt
+python auditsweeper.py
+```
+
+```bash
+cd certmanager
+pip install -r requirements.txt
+python checkupdate.py
+```
+
+```bash
+cd databreachdetector
+pip install -r requirements.txt
+python databreachdetector.py
+```
+
+Build a module's Docker image (run from the module directory, matching what
+`.github/workflows/push-trigger.yml` does per module):
+
+```bash
+cd auditsweeper
+docker build -t auditsweeper:local .
+```
+
+There are no unit or integration tests to run in this repo. The only CI
+quality gate is `sonar-check.yml`, which runs against the placeholder
+`pom.xml` at the repo root:
+
+```bash
+mvn -B verify sonar:sonar -Dsonar.projectKey=mosip_security-tools -Dsonar.organization=mosip -Dsonar.host.url=https://sonarcloud.io -DskipSigning=true
+```
+
+Helm chart linting happens in CI only (`chart-lint-publish.yml`, triggered on
+changes under `helm/**`) — there is no documented local lint command in this
+repo; use `helm lint helm/<module>` if you need to check a chart locally.
+
+## Configuration
+
+Every module follows the same convention: **environment variables are
+preferred; a checked-in `*.properties` file is the local-only fallback** used
+when the required environment variables are not all set. This is implemented
+directly in each script (e.g. `auditsweeper/auditsweeper.py`'s
+`get_db_credentials()`, `certmanager/checkupdate.py`'s
+`read_bootstrap_properties()`, `databreachdetector/databreachdetector.py`'s
+`deduce_sensitive_data_in_databases()`).
+
+In production, credentials are **not** committed — the `deploy/*/copy_secrets.sh`
+scripts pull an existing Kubernetes Secret (e.g. `postgres-postgresql`) into
+each module's namespace before Helm install; the Helm charts then mount that
+secret into the CronJob's environment. See `deploy/auditsweeper/copy_secrets.sh`
+and the corresponding `helm/*/templates/secrets.yaml` files.
+
+The properties files committed to this repo
+(`auditsweeper/local.properties`, `certmanager/bootstrap.properties`,
+`databreachdetector/db.properties`) currently hold masked/sandbox-style
+placeholder values (e.g. `HEdM***9ZXir7Tu2F`) pointing at MOSIP's own
+sandbox/dev hosts, and `certmanager/partner.properties` lists sample partner
+IDs — none of this is meant to be a real, usable credential. **Never replace
+these placeholder values with real credentials or secrets in a commit or PR.**
+See each module's `AGENTS.md` for the exact keys each file expects.
+
+## Project Structure Notes
+
+```text
+security-tools/
+├── auditsweeper/          # Postgres audit-log cleanup script + Dockerfile
+├── certmanager/            # Partner certificate renewal script + Dockerfile + README
+├── databreachdetector/     # PII scan script (WIP) + Dockerfile + README
+├── deploy/
+│   ├── auditsweeper/
+│   ├── mosipcertmanager/   # deploy scripts for the certmanager module
+│   └── databreachdetector/
+├── helm/
+│   ├── auditsweeper/
+│   ├── mosipcertmanager/   # helm chart for the certmanager module
+│   └── databreachdetector/
+├── .github/workflows/      # docker build, helm lint/publish, sonar scan
+├── pom.xml, src/Dummy.java # placeholder Maven project for the Sonar workflow only
+```
+
+Each module directory is self-contained: its Dockerfile `ADD`s or `COPY`s only
+files from within that same directory, so there are no cross-module imports
+or shared code to worry about when editing one module.
+
+## Development Workflow
+
+1. Fork the repo and branch from `develop` (the repo's default integration
+   branch — confirmed via `git ls-tree`/`gh api` at branch-creation time).
+2. Make changes scoped to a single module where possible; each module is
+   independently versioned, built, and deployed.
+3. If you change files under `helm/`, expect `chart-lint-publish.yml` to run
+   (it triggers only on `pull_request`/`push` paths matching `helm/**`).
+4. If you change `pom.xml` or `src/`, expect `sonar-check.yml` to run on push
+   to `develop`; this workflow does not run on pull requests.
+5. Any change under any module directory triggers `push-trigger.yml`'s
+   Docker build matrix on `pull_request` and on push to `master`, `1.*`,
+   `develop*`, `release*`, `MOSIP*`, or `update` branches.
+6. There is no automated test suite — validate script changes by running the
+   module locally against a test/sandbox database (or by manually reading
+   through the change, since this repo has no CI test gate).
+
+## Pull Request Guidelines
+
+- Follow the standard MOSIP contribution flow: fork, feature branch off
+  `develop`, PR back into `develop`.
+- Keep PRs scoped to one module (`auditsweeper`, `certmanager`, or
+  `databreachdetector`) unless the change is genuinely repo-wide (e.g. a
+  workflow file).
+- Sign off commits (`git commit -s`) per standard MOSIP DCO practice.
+- Do not include real hostnames, credentials, tokens, or partner IDs from any
+  live environment in a `*.properties` file, README, or commit message.
+- If you touch `helm/*/Chart.yaml`, bump the chart `version` so the
+  publish workflow produces a new package.
+
+## Repository-Specific Considerations
+
+- **Naming mismatch**: the source/module directory is `certmanager/`, but its
+  Helm chart and deploy folder are both named `mosipcertmanager`
+  (`helm/mosipcertmanager/`, `deploy/mosipcertmanager/`). Don't assume the
+  names always match when navigating the repo.
+- **`databreachdetector` is explicitly WIP** per its own README
+  (`# Databreach detector (WIP)`). Treat behavior changes there as
+  higher-risk/less-final than the other two modules.
+- **`certmanager` has a documented limitation**: its README states it
+  "can not handle IDA-CRED certificates" yet — don't assume full certificate
+  coverage when reasoning about its behavior.
+- **The root `pom.xml`/`src/Dummy.java` is a placeholder**, not real product
+  code — do not try to "complete" it or add real Java sources there unless
+  you are specifically changing how the Sonar workflow builds.
+- **`sonar-check.yml` only runs on push to `develop`**, not on pull requests —
+  don't expect a Sonar status check to appear on a PR from this repo's own
+  workflows.
+- Some scripts shell out to `openssl` and `kubectl` (e.g.
+  `certmanager/checkupdate.py` calls `os.popen("... openssl x509 ...")`, and
+  its Dockerfile installs `kubectl` for the `esignet` deployment restart) —
+  these are expected to run inside the module's own container, not on an
+  arbitrary local machine.
+
+## Agent rules
+
+### Do
+
+1. Scope changes to a single module directory unless the task is explicitly
+   repo-wide (e.g. a shared GitHub Actions workflow).
+2. Verify which module a file belongs to by its actual path before editing —
+   remember the `certmanager` / `mosipcertmanager` naming mismatch.
+3. Keep the environment-variable-preferred, properties-file-fallback pattern
+   intact when touching configuration-reading code in any module.
+4. Update the relevant module's `AGENTS.md`/README if you change its
+   configuration keys, CLI behavior, or dependencies.
+5. Use placeholder/masked values (matching the existing style) if you need to
+   add example configuration to a `*.properties` file.
+
+### Do not
+
+1. Do not commit real credentials, tokens, partner IDs, or hostnames into any
+   `*.properties` file, Dockerfile, Helm `values.yaml`, or workflow file.
+2. Do not assume this repo has a shared build, shared dependency set, or test
+   suite — none exists; don't invent `pytest`/`mvn test` commands that aren't
+   backed by real files.
+3. Do not treat `pom.xml`/`src/Dummy.java` as the repo's real application.
+4. Do not merge the three modules' code, dependencies, or Dockerfiles
+   together — they are intentionally independent.
+5. Do not remove or weaken the k8s-Secret-based credential flow
+   (`deploy/*/copy_secrets.sh` + `helm/*/templates/secrets.yaml`) in favor of
+   hardcoding credentials in a properties file.

--- a/auditsweeper/AGENTS.md
+++ b/auditsweeper/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+## Purpose
+
+`auditsweeper` is a single Python script that deletes old rows from the
+`audit.app_audit_log` table in the `mosip_audit` Postgres database. It is
+meant to run as a scheduled Kubernetes `CronJob` (see
+`../helm/auditsweeper/templates/cronjob.yaml`), not as a long-running
+service.
+
+## Layout
+
+```text
+auditsweeper/
+├── auditsweeper.py      # entire script: reads config, connects to Postgres, deletes old rows
+├── Dockerfile            # python:3.9 base, installs kubectl + requirements.txt, runs auditsweeper.py
+├── requirements.txt      # psycopg2-binary==2.9.1
+└── local.properties       # local-only fallback config (placeholder values, see below)
+```
+
+## How to run
+
+Locally, with dependencies installed:
+
+```bash
+cd auditsweeper
+pip install -r requirements.txt
+python auditsweeper.py
+```
+
+As a container:
+
+```bash
+cd auditsweeper
+docker build -t auditsweeper:local .
+docker run --rm auditsweeper:local
+```
+
+Deployed to a cluster via Helm, using the scripts in
+`../deploy/auditsweeper/` (`copy_cm.sh`, `copy_secrets.sh`, `install.sh`) —
+see `../deploy/auditsweeper/README.md` for the install steps.
+
+## Configuration
+
+`get_db_credentials()` in `auditsweeper.py` requires all five of these to be
+set as environment variables; if any are missing, it falls back to reading
+`local.properties` in the current working directory:
+
+- `db-host`
+- `db-port`
+- `db-su-user`
+- `postgres-password`
+- `log-age-days`
+
+The database name (`mosip_audit`) is hardcoded in the script, not
+configurable.
+
+`local.properties` in this repo currently holds sandbox-style masked
+placeholder values (e.g. `postgres-password=HEdM***9ZXir7Tu2F` pointing at
+`postgres.dev1.mosip.net`). In a real cluster deployment, `postgres-password`
+comes from a Kubernetes Secret copied in by
+`../deploy/auditsweeper/copy_secrets.sh` (which pulls the `postgres-postgresql`
+secret into the `auditsweeper` namespace), not from this file.
+
+## Agent rules
+
+### Do
+
+1. Keep `get_db_credentials()`'s "env vars first, `local.properties` fallback"
+   behavior intact if you touch it.
+2. Use masked/placeholder-style values if you add example config to
+   `local.properties`.
+
+### Do not
+
+1. Do not put a real database password into `local.properties`.
+2. Do not change the hardcoded `mosip_audit` database name without also
+   updating the Helm chart/values and this file.
+
+Parent guide: [../AGENTS.md](../AGENTS.md)

--- a/certmanager/AGENTS.md
+++ b/certmanager/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+This module already has its own user-facing `README.md` — read that first for
+feature/behavior details; this file adds AI-agent-specific notes on top of it
+rather than duplicating it.
+
+## Purpose
+
+`certmanager` (packaged/deployed as `mosipcertmanager` — see naming note
+below) checks MOSIP partner certificate expiry via the Partner Management
+System (PMS) API and, for certificates that are expired or inside the
+`pre-expiry-days` window, fetches the renewed certificate from the database,
+uploads it back to PMS, and propagates it to the dependent system for that
+partner type (eSignet, IDA, KeyManager for resident/digital-card partners, or
+PMS itself for other partner kinds). Runs as a Kubernetes `CronJob`.
+
+## Layout
+
+```text
+certmanager/
+├── checkupdate.py         # entire script: checks expiry, renews, uploads, restarts esignet
+├── README.md               # user-facing feature/config documentation (read this first)
+├── Dockerfile               # python:3.9 base, installs kubectl + requirements.txt
+├── requirements.txt         # psycopg2-binary, requests
+├── bootstrap.properties     # local-only fallback config (placeholder values)
+└── partner.properties       # local-only fallback list of partner IDs
+```
+
+Note the naming mismatch called out in the parent guide: this module's Helm
+chart and deploy scripts live under `../helm/mosipcertmanager/` and
+`../deploy/mosipcertmanager/`, not `certmanager`.
+
+## How to run
+
+```bash
+cd certmanager
+pip install -r requirements.txt
+python checkupdate.py
+```
+
+The script also shells out to the `openssl` CLI (via `os.popen(...)`) to read
+certificate expiry dates, and to `kubectl` (via `subprocess.run`) to restart
+the eSignet deployment after a successful eSignet certificate upload — both
+binaries are installed into the Docker image but must be available on `PATH`
+if you run the script outside the container.
+
+## Configuration
+
+`checkupdate.py` reads each of these from an environment variable first, and
+falls back to `read_bootstrap_properties()` (which parses `bootstrap.properties`
+line-by-line) if the environment variable is unset:
+
+- `db-host`, `db-port`, `db-su-user`, `postgres-password` — Postgres
+  connection used to read certificate data directly from `mosip_pms` and
+  `mosip_keymgr` databases when uploading a renewed certificate
+- `mosip-api-internal-host` — internal MOSIP API host, used for auth,
+  partner-manager, keymanager, and IDA calls
+- `mosip-api-host` (env var name) / `mosip-api-external-host` (properties-file
+  key) — external host, used only for the eSignet upload call
+- `mosip_deployment_client_secret` — client secret used to authenticate
+  against `/v1/authmanager/authenticate/clientidsecretkey`
+- `pre-expiry-days` — renewal window in days
+
+Two more variables are environment-only (no properties-file fallback):
+
+- `PARTNER_IDS_ENV` — comma-separated partner IDs; if unset, the script reads
+  `partner.properties`'s `PARTNER_ID=` line instead
+- `ns_esignet` — Kubernetes namespace to restart the `esignet` deployment in
+  after a successful eSignet certificate upload; if unset, the restart step
+  is skipped (with a printed warning), not treated as an error
+
+As with the other modules, `bootstrap.properties` in this repo holds masked
+sandbox-style placeholder values (e.g. `postgres-password = HEdMa9Z****Tu**`)
+pointing at `postgres.sandbox.mosip.net` — this is not a real usable
+credential, and in a cluster deployment the real values come from a
+Kubernetes Secret via `../deploy/mosipcertmanager/copy_secrets.sh`, not this
+file.
+
+## Repository-Specific Considerations
+
+- Per this module's own `README.md`, it currently **cannot handle IDA-CRED
+  certificates** — this is a documented, known gap, not a bug to silently
+  "fix" without understanding the intended scope.
+- The certificate-authentication request body sent to
+  `/v1/authmanager/authenticate/clientidsecretkey` uses literal string values
+  `"id": "string"` and `"version": "string"` — this matches the MOSIP auth
+  API's expected envelope shape and is not a placeholder left by mistake.
+
+## Agent rules
+
+### Do
+
+1. Read this module's `README.md` before making behavior changes — it
+   documents the partner-type-to-dependent-system mapping in detail.
+2. Preserve the "env var first, properties-file fallback" pattern for any new
+   configuration value you add.
+3. Remember the chart/deploy folder for this module is named
+   `mosipcertmanager`, not `certmanager`, when cross-referencing Helm/deploy
+   changes.
+
+### Do not
+
+1. Do not put a real `mosip_deployment_client_secret` or database password
+   into `bootstrap.properties`.
+2. Do not silently expand certificate handling to IDA-CRED certificates
+   without confirming that's the intended scope of your task — it's an
+   explicitly documented WIP gap.
+
+Parent guide: [../AGENTS.md](../AGENTS.md)

--- a/databreachdetector/AGENTS.md
+++ b/databreachdetector/AGENTS.md
@@ -1,0 +1,108 @@
+# AGENTS.md
+
+Parent guide: [../AGENTS.md](../AGENTS.md)
+
+This module already has its own short `README.md`, which marks it **WIP**.
+Read it first; this file adds AI-agent-specific notes on top of it.
+
+## Purpose
+
+`databreachdetector` scans rows of configured Postgres tables (currently just
+the `resident` schema of the `mosip_resident` database — see
+`databreachdetector.py`'s hardcoded `databases` list) for PII-shaped data
+using the `deduce` de-identification library, plus custom regex checks for
+emails, mobile numbers, names, ages, dates, URLs, and locations, and an ID
+checksum check (Verhoeff algorithm via `python-stdnum`). Findings are written
+to local text files and then uploaded to a MinIO/S3 bucket. Runs as a
+Kubernetes `CronJob`.
+
+## Layout
+
+```text
+databreachdetector/
+├── databreachdetector.py   # entire script: scan, deduce, write findings, push to MinIO
+├── README.md                 # WIP notice + one-line description
+├── Dockerfile                 # python:3.9 base, installs requirements.txt
+├── requirements.txt           # psycopg2-binary, python-stdnum, deduce, minio
+└── db.properties               # local-only fallback config (placeholder/blank values)
+```
+
+## How to run
+
+```bash
+cd databreachdetector
+pip install -r requirements.txt
+python databreachdetector.py
+```
+
+Running the script writes several report files into the current directory
+(`id.txt`, `mails.txt`, `mobile_numbers.txt`, `names.txt`, `ages.txt`,
+`dates.txt`, `url.txt`, `locations.txt`) before attempting to upload them to
+the configured MinIO bucket — expect these files to appear locally when
+testing.
+
+## Configuration
+
+`deduce_sensitive_data_in_databases()` checks whether **all** of the
+following environment variables are set; if even one is missing, it reads
+`db.properties` instead (via `configparser`, not a per-key fallback like the
+other two modules):
+
+- `db-server`, `db-port`, `db-su-user`, `postgres-password` — Postgres
+  connection (`PostgreSQL Connection` section in `db.properties`)
+- `s3-host`, `s3-region`, `s3-user-key`, `s3-user-secret`, `s3-bucket-name` —
+  MinIO/S3 connection (`MinIO Connection` section)
+
+`db.properties` also has two scan-tuning sections read unconditionally from
+the file (not overridable by environment variable in the current code):
+
+- `[Ignored Tables]` `ignore_tables` — comma-separated table names to skip
+- `[Ignored Columns]` `ignore_columns` — comma-separated column names to skip
+- `[disabled_f]` `disabled` — groups to exclude from the `deduce` scan (e.g.
+  `institutions`)
+
+In this repo, `db.properties`'s `postgres-password` is masked as `#######`
+and the MinIO secret fields are blank — there is no usable credential
+committed here. In a cluster deployment, real values come from a Kubernetes
+Secret via `../deploy/databreachdetector/copy_secrets.sh`, not this file.
+
+## Repository-Specific Considerations
+
+- This module is explicitly marked **WIP** by its own `README.md` — treat
+  behavior changes as less final/more likely to need rework than the other
+  two modules.
+- The regex-based detectors (`find_names`, `find_ages`, `find_dates`,
+  `find_urls`, `find_locations`) all use `re.match`, which only anchors at
+  the **start** of the string — this looks like it may be an unintentional
+  limitation (a match inside the middle of a longer string would be missed),
+  but it is existing behavior; don't "fix" it silently as part of an
+  unrelated change without flagging it, since it may be relied upon or may
+  be a known issue already tracked elsewhere.
+- Some MinIO-related error handling references `ResponseError` from
+  `minio.error`; this class exists in the older `minio` versions pinned in
+  `requirements.txt` (`minio==6.0.2`) — don't upgrade the `minio` dependency
+  without also checking this import still resolves.
+
+## Agent rules
+
+### Do
+
+1. Read `README.md`'s WIP notice before treating any behavior here as final.
+2. Preserve the "all env vars set, else read `db.properties`" fallback logic
+   if you touch configuration loading.
+3. Keep `ignore_tables`/`ignore_columns`/`disabled` scan-tuning read from
+   `db.properties` unless you're deliberately adding environment-variable
+   overrides for them (none exist today).
+
+### Do not
+
+1. Do not put a real database password or MinIO secret key into
+   `db.properties`.
+2. Do not silently change the `re.match`-based regex detectors to `re.search`
+   (or vice versa) as an incidental part of an unrelated change — call it out
+   explicitly if you believe it's a bug worth fixing.
+3. Do not upgrade `minio` in `requirements.txt` without verifying
+   `minio.error.ResponseError` (or its replacement) still exists in the new
+   version and updating the import accordingly.
+
+Parent guide: [../AGENTS.md](../AGENTS.md)

--- a/databreachdetector/AGENTS.md
+++ b/databreachdetector/AGENTS.md
@@ -39,7 +39,11 @@ Running the script writes several report files into the current directory
 (`id.txt`, `mails.txt`, `mobile_numbers.txt`, `names.txt`, `ages.txt`,
 `dates.txt`, `url.txt`, `locations.txt`) before attempting to upload them to
 the configured MinIO bucket — expect these files to appear locally when
-testing.
+testing. The script does not delete them after upload.
+
+These reports can contain sensitive PII findings. Restrict local access, do
+not commit or share the files, and delete them yourself once the MinIO
+upload is confirmed.
 
 ## Configuration
 


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md hub plus per-module AGENTS.md guides (auditsweeper, certmanager, databreachdetector), since this repo is a collection of three independent Python-based ops/security tools rather than a single application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide development guidance covering project structure, technology, build and test workflows, configuration, credentials, and contribution practices.
  * Added module-specific guidance for auditing, certificate management, and data-breach detection tools.
  * Documented execution options, configuration requirements, deployment considerations, generated reports, and security constraints.
  * Clarified development rules, known limitations, fallback behavior, and safe handling of sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->